### PR TITLE
Fixed invalid check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.1.2
+=====
+
+*   (bug) Fixed invalid check, that prevented loading stored git version info if the tag was `null`.
+
+
 1.1.1
 =====
 

--- a/src/Git/Data/InstalledGitCommit.php
+++ b/src/Git/Data/InstalledGitCommit.php
@@ -45,7 +45,8 @@ final class InstalledGitCommit
 	public static function fromArray (array $data) : ?self
 	{
 		return (
-			isset($data["commit"], $data["tag"])
+			\array_key_exists("commit", $data)
+			&& \array_key_exists("tag", $data)
 			&& \is_string($data["commit"])
 			&& (null === $data["tag"] || \is_string($data["tag"]))
 		)

--- a/tests/Git/Data/InstalledGitCommitTest.php
+++ b/tests/Git/Data/InstalledGitCommitTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Torr\Hosting\Git\Data;
+
+use PHPUnit\Framework\TestCase;
+use Torr\Hosting\Git\Data\InstalledGitCommit;
+
+final class InstalledGitCommitTest extends TestCase
+{
+	public function provideFromArray () : iterable
+	{
+		yield [["commit" => "test", "tag" => "1.0.0"], new InstalledGitCommit("test", "1.0.0")];
+		yield [["commit" => "test", "tag" => null], new InstalledGitCommit("test", null)];
+		yield [["commit" => "test", "tag" => "1.0.0", "additional_entries" => "allowed"], new InstalledGitCommit("test", "1.0.0")];
+		yield [[], null];
+	}
+
+	/**
+	 * @dataProvider provideFromArray
+	 */
+	public function testFromArray (array $data, ?InstalledGitCommit $expected) : void
+	{
+		$actual = InstalledGitCommit::fromArray($data);
+		self::assertEquals($expected, $actual);
+	}
+}


### PR DESCRIPTION
… that prevented loading stored git version info if the tag was `null`